### PR TITLE
Ensure assessment results page respects selected test

### DIFF
--- a/src/app/assessments/page.tsx
+++ b/src/app/assessments/page.tsx
@@ -102,9 +102,11 @@ export default function AssessmentsPage() {
       console.warn('🚨 CRISIS DETECTED - Immediate intervention needed!')
       router.push('/crisis-support')
     } else {
-      // All assessments completed - redirect to results page to show comprehensive results
+      // All assessments completed - redirect to results page for the last assessment
       console.log('All assessments completed - showing final results')
-      router.push('/results')
+      const assessmentIds = Object.keys(results)
+      const lastAssessmentId = assessmentIds[assessmentIds.length - 1]
+      router.push(`/results?assessment=${lastAssessmentId}`)
     }
   }
 

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -7,7 +7,7 @@
 
 import React, { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { AssessmentResult } from '@/data/assessments'
 import { UserProfile } from '@/data/assessment-integration'
 import AssessmentResults from '@/components/assessment/AssessmentResults'
@@ -24,6 +24,7 @@ export default function ResultsPage() {
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null)
   const [loading, setLoading] = useState(true)
   const router = useRouter()
+  const searchParams = useSearchParams()
 
   useEffect(() => {
     const loadResults = async () => {
@@ -239,7 +240,8 @@ export default function ResultsPage() {
     )
   }
 
-  const resultEntries = Object.entries(results)
+  const filterId = searchParams.get('assessment')
+  const resultEntries = Object.entries(results).filter(([id]) => !filterId || id === filterId)
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100">


### PR DESCRIPTION
## Summary
- Pass the ID of the most recently completed assessment when redirecting to the results page
- Filter results on the results page by an optional `assessment` query parameter to show the correct assessment's outcome

## Testing
- `npm run lint` *(fails: many pre-existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b973d3c0f88330a9eab1b212dc432d