### PR TITLE
Redesign sign-in page with analytics tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
     "test:setup": "tsx scripts/setup-test-data-simple.ts",
     "test:cleanup": "tsx scripts/setup-test-data-simple.ts cleanup",
     "clear-assessments": "tsx scripts/clear-assessment-data.ts",
@@ -52,9 +53,14 @@
     "dotenv": "^17.2.2",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
+    "jsdom": "^24.0.0",
     "supabase": "^2.39.2",
     "tailwindcss": "^4",
     "tsx": "^4.20.5",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "vite-tsconfig-paths": "^4.3.1"
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,6 +48,16 @@
   --color-input: #e2e8f0;
   --color-ring: #0ea5e9;
   --radius: 0.75rem;
+
+  /* MindWell brand tokens */
+  --brand-50: #ECF6F4;
+  --brand-500: #2E7D74;
+  --brand-600: #24685F;
+  --ink-900: #0F172A;
+  --ink-600: #475569;
+  --ink-400: #94A3B8;
+  --error-600: #B91C1C;
+  --success-600: #177245;
 }
 
 /* Dark theme overrides for Purple Sparkle */

--- a/src/components/screens/LoginScreen.test.tsx
+++ b/src/components/screens/LoginScreen.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import { LoginScreen } from './LoginScreen'
+
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }))
+vi.mock('@/components/providers/AuthProvider', () => ({ useAuth: () => ({ user: null }) }))
+vi.mock('@/lib/supabase', () => ({
+  supabase: { auth: { signInWithPassword: vi.fn().mockResolvedValue({ error: null }), signInWithOAuth: vi.fn() } }
+}))
+
+describe('LoginScreen', () => {
+  it('shows validation errors when fields are empty', async () => {
+    const { track } = await import('@/lib/analytics')
+    render(<LoginScreen />)
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
+    expect(await screen.findByText('Please enter your email.')).toBeInTheDocument()
+    expect(await screen.findByText('Please enter your password.')).toBeInTheDocument()
+    expect(track).toHaveBeenCalledWith('signin_error', { type: 'validation' })
+  })
+
+  it('toggles password visibility', () => {
+    render(<LoginScreen />)
+    const toggle = screen.getByRole('button', { name: /show password/i })
+    const input = screen.getByLabelText('Password') as HTMLInputElement
+    expect(input.type).toBe('password')
+    fireEvent.click(toggle)
+    expect(input.type).toBe('text')
+    expect(toggle).toHaveAttribute('aria-label', 'Hide password')
+  })
+
+  it('emits analytics events on successful submit', async () => {
+    const { track } = await import('@/lib/analytics')
+    const { supabase } = await import('@/lib/supabase')
+    ;(supabase.auth.signInWithPassword as any).mockResolvedValue({ error: null })
+    render(<LoginScreen />)
+    fireEvent.change(screen.getByLabelText('Email address'), { target: { value: 'test@example.com' } })
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } })
+    fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
+    await waitFor(() => {
+      expect(track).toHaveBeenCalledWith('signin_submit', { method: 'password', rememberMe: false })
+    })
+    await waitFor(() => {
+      expect(track).toHaveBeenCalledWith('signin_success', { method: 'password' })
+    })
+  })
+})

--- a/src/components/screens/LoginScreen.tsx
+++ b/src/components/screens/LoginScreen.tsx
@@ -1,302 +1,281 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
+import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
-import { supabase } from '@/lib/supabase'
-import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { useRouter } from 'next/navigation'
+import { Mail, Lock, Eye, EyeOff, Shield, Apple } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/components/providers/AuthProvider'
-
-// Material Symbols icons import
-import 'material-symbols/outlined.css'
+import { track } from '@/lib/analytics'
 
 export function LoginScreen() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [rememberMe, setRememberMe] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
+
+  const [emailError, setEmailError] = useState('')
+  const [passwordError, setPasswordError] = useState('')
+  const [formError, setFormError] = useState('')
+
+  const emailRef = useRef<HTMLInputElement>(null)
   const router = useRouter()
   const { user } = useAuth()
+  const enableApple = process.env.NEXT_PUBLIC_ENABLE_APPLE === 'true'
 
-  // Redirect to dashboard when user is authenticated
+  useEffect(() => {
+    emailRef.current?.focus()
+    const device = typeof window !== 'undefined' && window.innerWidth < 768 ? 'mobile' : 'desktop'
+    track('signin_view', { device, abBucket: 'default' })
+    const savedRemember = typeof window !== 'undefined' && localStorage.getItem('rememberMe') === 'true'
+    setRememberMe(savedRemember)
+  }, [])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('rememberMe', rememberMe ? 'true' : 'false')
+    }
+  }, [rememberMe])
+
   useEffect(() => {
     if (user) {
-      console.log('User authenticated, redirecting to dashboard...')
       router.push('/dashboard')
     }
   }, [user, router])
 
+  const validate = () => {
+    let valid = true
+    setEmailError('')
+    setPasswordError('')
+
+    if (!email) {
+      setEmailError('Please enter your email.')
+      valid = false
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailError('That doesn’t look like a valid email.')
+      valid = false
+    }
+
+    if (!password) {
+      setPasswordError('Please enter your password.')
+      valid = false
+    }
+
+    return valid
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!email || !password) {
-      setError('Please fill in all fields')
+    setFormError('')
+
+    if (!validate()) {
+      track('signin_error', { type: 'validation' })
       return
     }
 
     setLoading(true)
-    setError('')
+    track('signin_submit', { method: 'password', rememberMe })
 
     try {
-      const { error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      })
-
+      const { error } = await supabase.auth.signInWithPassword({ email, password })
       if (error) {
-        setError(error.message)
+        setPasswordError('Email or password didn’t match. Try again or reset your password.')
+        track('signin_error', { type: 'auth' })
       } else {
-        console.log('Login successful, auth state will update automatically...')
-        // Navigation will be handled by useEffect when user state updates
+        track('signin_success', { method: 'password' })
       }
-    } catch (err) {
-      setError('An unexpected error occurred')
+    } catch {
+      setFormError('We couldn’t reach the server. Please try again.')
+      track('signin_error', { type: 'network' })
     } finally {
       setLoading(false)
     }
   }
 
   const handleGoogleSignIn = async () => {
+    track('sso_click', { provider: 'google' })
+    track('signin_submit', { method: 'google', rememberMe: false })
     setLoading(true)
-    setError('')
-
     try {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
-        options: {
-          redirectTo: `${window.location.origin}/auth/callback`
-        }
+        options: { redirectTo: `${window.location.origin}/auth/callback` }
       })
-
-      if (error) throw error
-    } catch (error: any) {
-      setError(error.message)
+      if (error) {
+        setFormError('We couldn’t reach the server. Please try again.')
+        track('signin_error', { type: 'network' })
+        setLoading(false)
+      } else {
+        track('signin_success', { method: 'google' })
+      }
+    } catch {
+      setFormError('We couldn’t reach the server. Please try again.')
+      track('signin_error', { type: 'network' })
       setLoading(false)
     }
   }
 
+  const handleAppleSignIn = async () => {
+    track('sso_click', { provider: 'apple' })
+    track('signin_submit', { method: 'apple', rememberMe: false })
+    setLoading(true)
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'apple',
+        options: { redirectTo: `${window.location.origin}/auth/callback` }
+      })
+      if (error) {
+        setFormError('We couldn’t reach the server. Please try again.')
+        track('signin_error', { type: 'network' })
+        setLoading(false)
+      } else {
+        track('signin_success', { method: 'apple' })
+      }
+    } catch {
+      setFormError('We couldn’t reach the server. Please try again.')
+      track('signin_error', { type: 'network' })
+      setLoading(false)
+    }
+  }
+
+  const isValid =
+    email.length > 0 &&
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) &&
+    password.length > 0
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-brand-green-50 via-white to-brand-green-100 flex">
-      {/* Left Side - Illustration */}
-      <div className="hidden lg:flex lg:w-1/2 relative overflow-hidden">
-        {/* Glassmorphic Background Elements */}
-        <div className="absolute inset-0 bg-gradient-to-br from-brand-green-100/50 to-brand-green-200/30"></div>
-        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-brand-green-200/20 rounded-full blur-3xl"></div>
-        <div className="absolute bottom-1/4 right-1/4 w-80 h-80 bg-brand-green-300/15 rounded-full blur-3xl"></div>
-
-        {/* SVG Illustration */}
-        <div className="relative z-10 flex items-center justify-center w-full p-12">
-          <motion.div
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 0.8, ease: "easeOut" }}
-            className="w-full max-w-lg"
-          >
-            <img
-              src="/assets/Peace_of_mind-bro_2.svg"
-              alt="Peace of mind illustration"
-              className="w-full h-auto drop-shadow-2xl"
-            />
-          </motion.div>
-        </div>
-
-        {/* Inspirational Text Overlay */}
-        <div className="absolute bottom-12 left-12 right-12 z-20">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.4 }}
-            className="glassmorphic rounded-2xl p-6 text-center"
-          >
-            <h3 className="text-xl font-semibold text-brand-green-800 mb-2">
-              Find Your Inner Peace
-            </h3>
-            <p className="text-brand-green-700/80 text-sm leading-relaxed">
-              Welcome back to your journey of self-discovery and emotional wellness.
-              Your safe space awaits.
-            </p>
-          </motion.div>
+    <div className="min-h-screen grid md:grid-cols-2">
+      <div className="hidden md:flex flex-col justify-center items-center bg-[radial-gradient(circle,var(--brand-50),transparent)] p-8">
+        <img src="/assets/signin_reflection_v2.webp" alt="" className="max-w-md w-full mb-8" />
+        <div className="max-w-md text-center">
+          <h5 className="text-xl font-semibold text-[var(--ink-900)] mb-2">Find Your Inner Peace</h5>
+          <p className="text-sm text-[var(--ink-600)]">Welcome back to a calmer you. We’re here, judgment-free and always on your side.</p>
         </div>
       </div>
-
-      {/* Right Side - Login Form */}
-      <div className="w-full lg:w-1/2 flex items-center justify-center px-4 py-8 lg:px-12">
-        {/* Mobile Background Elements */}
-        <div className="absolute inset-0 overflow-hidden pointer-events-none lg:hidden">
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-brand-green-200/20 rounded-full blur-3xl"></div>
-          <div className="absolute bottom-1/4 right-1/4 w-80 h-80 bg-brand-green-300/15 rounded-full blur-3xl"></div>
-        </div>
-
-        <div className="relative w-full max-w-md">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            className="glassmorphic rounded-3xl p-8 shadow-2xl border border-white/20"
-          >
-            {/* Header */}
-            <div className="text-center mb-8">
-              <Link href="/" className="inline-block">
-                <motion.div
-                  className="flex items-center justify-center gap-3 mb-6"
-                  whileHover={{ scale: 1.02 }}
-                  transition={{ type: "spring", stiffness: 400, damping: 25 }}
-                >
-                  <span
-                    className="material-symbols-outlined text-4xl"
-                    style={{ color: '#1f3d42' }}
-                  >
-                    psychology
-                  </span>
-                  <h1
-                    className="text-3xl font-bold"
-                    style={{ color: '#1f3d42' }}
-                  >
-                    MindWell
-                  </h1>
-                </motion.div>
-              </Link>
-              <h2 className="text-2xl font-semibold text-zinc-900 mb-2">Welcome back</h2>
-              <p className="text-zinc-700 font-medium">Continue your wellness journey</p>
-            </div>
-
-            {/* Error Message */}
-            {error && (
-              <motion.div
-                initial={{ opacity: 0, scale: 0.95 }}
-                animate={{ opacity: 1, scale: 1 }}
-                className="mb-6 p-4 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm"
-              >
-                {error}
-              </motion.div>
-            )}
-
-            {/* Login Form */}
-            <form onSubmit={handleSubmit} className="space-y-6">
-              <div>
-                <label htmlFor="email" className="block text-sm font-semibold text-zinc-800 mb-2">
-                  Email address
-                </label>
+      <div className="flex items-center justify-center p-4">
+        <div className="w-full max-w-[420px] bg-white rounded-[1.25rem] shadow-xl p-7 space-y-5">
+          <header className="space-y-2">
+            <h2 className="text-2xl font-semibold text-[var(--ink-900)]">Welcome back. Your safe space is waiting.</h2>
+            <p className="text-sm text-[var(--ink-600)]">Sign in to continue your journey to emotional wellness.</p>
+          </header>
+          <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+            <div className="space-y-1">
+              <label htmlFor="email" className="text-sm font-medium text-[var(--ink-900)]">Email address</label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-[var(--ink-400)]" aria-hidden="true" />
                 <input
+                  ref={emailRef}
                   id="email"
                   type="email"
+                  autoComplete="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  required
-                  disabled={loading}
-                  className="w-full px-4 py-4 bg-white/90 border border-zinc-300 rounded-xl text-zinc-900 placeholder-zinc-600 focus:outline-none focus:ring-2 focus:ring-brand-green-600 focus:border-brand-green-600 transition-all duration-300 font-medium"
-                  placeholder="Enter your email"
-                  style={{
-                    backgroundColor: 'rgba(255, 255, 255, 0.95)',
-                    color: '#111827'
-                  }}
+                  placeholder="you@email.com"
+                  className="w-full h-12 pl-10 pr-3 rounded-lg border border-[var(--color-input)] text-[var(--ink-900)] placeholder-[var(--ink-400)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-500)] focus:border-[var(--brand-500)]"
+                  aria-describedby={emailError ? 'email-error' : undefined}
+                  aria-invalid={emailError ? 'true' : 'false'}
                 />
               </div>
+              {emailError && <p id="email-error" className="text-sm text-[var(--error-600)]">{emailError}</p>}
+            </div>
 
-              <div>
-                <label htmlFor="password" className="block text-sm font-semibold text-zinc-800 mb-2">
-                  Password
-                </label>
+            <div className="space-y-1">
+              <label htmlFor="password" className="text-sm font-medium text-[var(--ink-900)]">Password</label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-[var(--ink-400)]" aria-hidden="true" />
                 <input
                   id="password"
-                  type="password"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="current-password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  required
-                  disabled={loading}
-                  className="w-full px-4 py-4 bg-white/90 border border-zinc-300 rounded-xl text-zinc-900 placeholder-zinc-600 focus:outline-none focus:ring-2 focus:ring-brand-green-600 focus:border-brand-green-600 transition-all duration-300 font-medium"
-                  placeholder="Enter your password"
-                  style={{
-                    backgroundColor: 'rgba(255, 255, 255, 0.95)',
-                    color: '#111827'
-                  }}
+                  placeholder="••••••••"
+                  className="w-full h-12 pl-10 pr-10 rounded-lg border border-[var(--color-input)] text-[var(--ink-900)] placeholder-[var(--ink-400)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-500)] focus:border-[var(--brand-500)]"
+                  aria-describedby={`${passwordError ? 'password-error ' : ''}privacy-note`.trim()}
+                  aria-invalid={passwordError ? 'true' : 'false'}
                 />
-              </div>
-
-              <div className="flex items-center justify-between text-sm">
-                <label className="flex items-center">
-                  <input type="checkbox" className="rounded border-zinc-300 text-brand-green-600 focus:ring-brand-green-500" />
-                  <span className="ml-2 text-zinc-700 font-medium">Remember me</span>
-                </label>
-                <Link
-                  href="/forgot-password"
-                  className="text-brand-green-700 hover:text-brand-green-800 transition-colors font-semibold"
-                  style={{ color: '#1f3d42' }}
-                >
-                  Forgot password?
-                </Link>
-              </div>
-
-              <div className="space-y-4">
-                <motion.button
-                  type="submit"
-                  disabled={loading}
-                  className="w-full bg-brand-green-700 hover:bg-brand-green-800 text-white font-semibold py-4 rounded-xl transition-all duration-300 shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 border-0"
-                  style={{
-                    backgroundColor: loading ? '#1f3d42' : '#1f3d42',
-                    color: '#ffffff',
-                    textShadow: '0 1px 2px rgba(0, 0, 0, 0.1)'
-                  }}
-                  whileHover={{ scale: loading ? 1 : 1.02 }}
-                  whileTap={{ scale: loading ? 1 : 0.98 }}
-                >
-                  {loading ? (
-                    <>
-                      <LoadingSpinner size="sm" />
-                      <span style={{ color: '#ffffff' }}>Signing in...</span>
-                    </>
-                  ) : (
-                    <span style={{ color: '#ffffff' }}>Sign in</span>
-                  )}
-                </motion.button>
-
-                <div className="relative">
-                  <div className="absolute inset-0 flex items-center">
-                    <div className="w-full border-t border-zinc-300/50"></div>
-                  </div>
-                  <div className="relative flex justify-center text-sm">
-                    <span className="px-4 bg-white/80 text-zinc-500 font-medium">or continue with</span>
-                  </div>
-                </div>
-
-                <motion.button
+                <button
                   type="button"
-                  onClick={handleGoogleSignIn}
-                  disabled={loading}
-                  className="w-full bg-white hover:bg-gray-50 border border-zinc-300 text-zinc-700 font-semibold py-4 rounded-xl transition-all duration-300 shadow-sm hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-3"
-                  style={{
-                    backgroundColor: '#ffffff',
-                    color: '#374151',
-                    textShadow: 'none'
-                  }}
-                  whileHover={{ scale: loading ? 1 : 1.02 }}
-                  whileTap={{ scale: loading ? 1 : 0.98 }}
+                  onClick={() => setShowPassword((s) => !s)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 h-6 w-6 text-[var(--ink-600)] flex items-center justify-center"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  aria-pressed={showPassword}
                 >
-                  <svg className="w-5 h-5" viewBox="0 0 24 24">
-                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                  </svg>
-                  <span style={{ color: '#374151' }}>Continue with Google</span>
-                </motion.button>
+                  {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                </button>
               </div>
-            </form>
-
-            {/* Footer */}
-            <div className="text-center pt-6 border-t border-zinc-200/50 mt-8">
-              <p className="text-zinc-700 text-sm font-medium">
-                Don't have an account?{' '}
-                <Link
-                  href="/signup"
-                  className="text-brand-green-700 hover:text-brand-green-800 font-semibold transition-colors"
-                  style={{ color: '#1f3d42' }}
-                >
-                  Sign up
-                </Link>
+              <p id="privacy-note" className="text-xs text-[var(--ink-400)] flex items-center gap-1">
+                <Shield className="h-3.5 w-3.5" aria-hidden="true" />
+                Your information is private and secure.
               </p>
+              {passwordError && <p id="password-error" className="text-sm text-[var(--error-600)]">{passwordError}</p>}
             </div>
-          </motion.div>
+
+            <div className="flex items-center justify-between">
+              <label htmlFor="remember" className="flex items-center gap-2 text-sm text-[var(--ink-600)]">
+                <input
+                  id="remember"
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-[var(--color-input)] text-[var(--brand-500)] focus:ring-[var(--brand-500)]"
+                  checked={rememberMe}
+                  onChange={(e) => setRememberMe(e.target.checked)}
+                />
+                Remember me
+              </label>
+              <Link href="/reset-password" className="text-sm text-[var(--brand-500)] hover:text-[var(--brand-600)]">Forgot password?</Link>
+            </div>
+
+            {formError && <p className="text-sm text-[var(--error-600)]">{formError}</p>}
+
+            <button
+              type="submit"
+              id="signin-submit"
+              disabled={loading || !isValid}
+              className="w-full h-12 rounded-lg bg-[var(--brand-500)] text-white font-semibold hover:bg-[var(--brand-600)] disabled:opacity-60"
+            >
+              {loading ? 'Signing in…' : 'Sign in'}
+            </button>
+          </form>
+
+          <div className="flex items-center gap-2">
+            <hr className="flex-grow border-[var(--color-input)]" />
+            <span className="text-sm text-[var(--ink-400)]">or continue with</span>
+            <hr className="flex-grow border-[var(--color-input)]" />
+          </div>
+
+          <div className="space-y-3">
+            <button
+              type="button"
+              onClick={handleGoogleSignIn}
+              className="w-full h-12 rounded-lg border border-[var(--color-input)] flex items-center justify-center gap-2 hover:bg-[var(--brand-50)] text-[var(--ink-600)]"
+            >
+              <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+              </svg>
+              Continue with Google
+            </button>
+            {enableApple && (
+              <button
+                type="button"
+                onClick={handleAppleSignIn}
+                className="w-full h-12 rounded-lg border border-[var(--color-input)] flex items-center justify-center gap-2 hover:bg-[var(--brand-50)] text-[var(--ink-600)]"
+              >
+                <Apple className="h-5 w-5" aria-hidden="true" />
+                Continue with Apple
+              </button>
+            )}
+          </div>
+
+          <p className="text-center text-sm text-[var(--ink-600)]">
+            New here?{' '}
+            <Link href="/signup" className="text-[var(--brand-500)] hover:text-[var(--brand-600)]">
+              Create your free safe space.
+            </Link>
+          </p>
         </div>
       </div>
     </div>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,17 @@
+export type AnalyticsEvent =
+  | 'signin_view'
+  | 'signin_submit'
+  | 'signin_error'
+  | 'sso_click'
+  | 'signin_success'
+
+export interface AnalyticsProps {
+  [key: string]: any
+}
+
+export function track(event: AnalyticsEvent, props: AnalyticsProps = {}): void {
+  if (process.env.NODE_ENV !== 'test') {
+    // Placeholder for real analytics integration
+    console.log('analytics event', event, props)
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    globals: true
+  }
+})


### PR DESCRIPTION
## Summary
- revamp sign-in screen layout, copy, accessibility, and SSO options
- introduce brand color tokens and analytics tracking utility
- add basic test scaffolding for sign-in interactions

## Testing
- `npm test` (fails: vitest not found)
- `npm run lint` (fails: numerous lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68ba03b4429883309badfd6d2f20f5f0